### PR TITLE
Relative import shoud be last. #5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@ __pycache__
 *.egg-info
 
 *.pyc
+
+build
+dist

--- a/import_order/sort.py
+++ b/import_order/sort.py
@@ -10,6 +10,19 @@ CAMEL_CASE_RE = re.compile(r'[A-Z][a-z0-9]+')
 Argument = namedtuple('Argument', ['files', 'local_packages', 'directories'])
 
 
+def package_type_order(future, stdlib, site, relative):
+    order = 100
+    if future:
+        order = 0
+    elif stdlib:
+        order = 1
+    elif site:
+        order = 2
+    elif not relative:
+        order = 3
+    return order
+
+
 def canonical_sort_key(original_name, lineno, col_offset, relative,
                        local_package_names):
     # Replace '_' (95) with '~' (128) to make it below 'z' (122)
@@ -41,7 +54,7 @@ def canonical_sort_key(original_name, lineno, col_offset, relative,
     return (
         # FIXME: refactor it to use namedtuple
         # 1. Order: __future__, standard libraries, site-packages, local
-        (0 if future else (1 if stdlib else (2 if site else 3))),
+        package_type_order(future, stdlib, site, relative),
         from_ or first_name.lower(),
         # 2. CONSTANT_NAMES must be the first
         not variable.isupper() if relative else None,

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,4 +1,4 @@
-from import_order.sort import sort_by_type
+from import_order.sort import sort_by_type, sort_import_names
 
 
 def test_sort_by_type():
@@ -10,3 +10,10 @@ def test_sort_by_type():
     assert set(argument.files) == set(files)
     assert set(argument.local_packages) == set(packages)
     assert set(argument.directories) == set(directories)
+
+
+def test_sort_relative_import_belower():
+    local_package_names = ['hello']
+    import_names = [('hello.b', 1, 0, False), ('.a', 2, 0, True)]
+    sorted_ = sort_import_names(import_names, local_package_names)
+    assert import_names == sorted_


### PR DESCRIPTION
relatvie import should be last in import order even if it treat as a local package.

``` python
#in hello.__init__
#yes
from hello import b

from . import a

#no
from . import a
from hello import b
```
