### PR TITLE
Fix `None` cannot be orderable in python3.x

### DIFF
--- a/import_order/sort.py
+++ b/import_order/sort.py
@@ -23,6 +23,16 @@ def package_type_order(future, stdlib, site, relative):
     return order
 
 
+def condition_order(condition, relative):
+    if not relative:
+        order = 2
+    elif not condition:
+        order = 1
+    else:
+        order = 0
+    return order
+
+
 def canonical_sort_key(original_name, lineno, col_offset, relative,
                        local_package_names):
     # Replace '_' (95) with '~' (128) to make it below 'z' (122)
@@ -57,9 +67,9 @@ def canonical_sort_key(original_name, lineno, col_offset, relative,
         package_type_order(future, stdlib, site, relative),
         from_ or first_name.lower(),
         # 2. CONSTANT_NAMES must be the first
-        not variable.isupper() if relative else None,
+        condition_order(variable.isupper(), relative),
         # 3. ClassNames must be the second
-        not CAMEL_CASE_RE.search(variable) if relative else None,
+        condition_order(CAMEL_CASE_RE.search(variable), relative),
         # 4. Rest must be in alphabetical order
         name.lower()
     )

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -17,3 +17,31 @@ def test_sort_relative_import_belower():
     import_names = [('hello.b', 1, 0, False), ('.a', 2, 0, True)]
     sorted_ = sort_import_names(import_names, local_package_names)
     assert import_names == sorted_
+
+
+def test_sort_constant():
+    local_package_names = ['hello']
+    import_names = [('.FOO', 1, 0, True), ('.foo', 2, 0, True)]
+    sorted_ = sort_import_names(import_names, local_package_names)
+    assert import_names == sorted_
+
+
+def test_sort_class_name():
+    local_package_names = ['hello']
+    import_names = [('.FooClass', 1, 0, True), ('.foo', 2, 0, True)]
+    sorted_ = sort_import_names(import_names, local_package_names)
+    assert import_names == sorted_
+
+
+def test_sort_all():
+    local_package_names = ['hello']
+    import_names = [
+        ('re.compile', 1, 0, False),
+        ('pygments.highlight', 2, 0, False),
+        ('hello.FOO', 3, 0, False),
+        ('hello.foo', 3, 0, False),
+        ('.FooClass', 4, 0, True),
+        ('.a', 4, 0, True),
+    ]
+    sorted_ = sort_import_names(import_names, local_package_names)
+    assert import_names == sorted_


### PR DESCRIPTION
- when `relative` is `False`, return 2 instead of `None`
- certain condition is `False` return 1 instead of `False`
- else 0
