### PR TITLE
Treat uninstalled module as a local packages with --only-file #15

### DIFF
--- a/import_order/listing.py
+++ b/import_order/listing.py
@@ -20,10 +20,14 @@ def list_site_packages_paths():
     except KeyError:
         pass
     else:
+        virtualenv_src_path = os.path.join(virtualenv_path, 'src')
         site_packages_paths.update(
             path
             for path in sys.path
-            if path.startswith(virtualenv_path) and 'site-packages' in path
+            if path.startswith(virtualenv_path) and (
+                'site-packages' in path or
+                path.startswith(virtualenv_src_path)
+            )
         )
     return site_packages_paths
 

--- a/import_order/sort.py
+++ b/import_order/sort.py
@@ -55,12 +55,21 @@ def canonical_sort_key(original_name, lineno, col_offset, relative,
         site = True
         stdlib = False
     else:
-        site = getattr(
-            __import__(first_name.replace('~', '_')),
-            '__file__',
-            ''
-        ).startswith(tuple(list_site_packages_paths()))
-        stdlib = not site
+        try:
+            site = getattr(
+                __import__(first_name.replace('~', '_')),
+                '__file__',
+                ''
+            ).startswith(tuple(list_site_packages_paths()))
+        except ImportError as e:
+            if not local_package_names:
+                site = False
+                stdlib = False
+                local = True
+            else:
+                raise e
+        else:
+            stdlib = not site
     return (
         # FIXME: refactor it to use namedtuple
         # 1. Order: __future__, standard libraries, site-packages, local

--- a/import_order/sort.py
+++ b/import_order/sort.py
@@ -56,11 +56,7 @@ def canonical_sort_key(original_name, lineno, col_offset, relative,
         stdlib = False
     else:
         try:
-            site = getattr(
-                __import__(first_name.replace('~', '_')),
-                '__file__',
-                ''
-            ).startswith(tuple(list_site_packages_paths()))
+            imported = __import__(first_name.replace('~', '_'))
         except ImportError as e:
             if not local_package_names:
                 site = False
@@ -69,6 +65,11 @@ def canonical_sort_key(original_name, lineno, col_offset, relative,
             else:
                 raise e
         else:
+            site = getattr(
+                imported,
+                '__file__',
+                ''
+            ).startswith(tuple(list_site_packages_paths()))
             stdlib = not site
     return (
         # FIXME: refactor it to use namedtuple

--- a/tests/filter_test.py
+++ b/tests/filter_test.py
@@ -29,7 +29,7 @@ def test_filter_exclude():
              'tests/mock.py']
     exclude_filter = Exclude(['tests/mock.py'])
     assert set(exclude_filter.apply(files)) == set(['tests/test_dir/foo.py',
-                                              'tests/test_dir/bar.py'])
+                                                    'tests/test_dir/bar.py'])
     exclude_filter = Exclude(['tests/test_dir'])
     assert set(exclude_filter.apply(files)) == set(['tests/mock.py'])
     exclude_filter = Exclude(['tests/test_dir/foo.py',


### PR DESCRIPTION
- treat uninstall module as a local packages when `--only-file` option is given.
  - to check order of uninstalled module, it is impossible that find a module is really exist
  - but, it supports
    - project that don't make it a package
    - single script file
- check VITUAL_ENV/src to detect editable modules

close #15
