### PR TITLE
Support py3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ build
 dist
 
 .tox
+.cache

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ python:
 - 2.7
 - 3.3
 - 3.4
+- 3.5
 install:
 - pip install .
 - pip install -e .[tests]

--- a/import_order/listing.py
+++ b/import_order/listing.py
@@ -12,7 +12,11 @@ def list_site_packages_paths():
     except AttributeError:
         pass
     try:
-        site_packages_paths.update(site.getusersitepackages())
+        user_site = site.getusersitepackages()
+        if isinstance(user_site, str):
+            site_packages_paths.add(user_site)
+        else:
+            site_packages_paths.update(user_site)
     except AttributeError:
         pass
     try:

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ setup(
         'Programming Language :: Python :: 3',
         'Programming Language :: Python :: 3.3',
         'Programming Language :: Python :: 3.4',
+        'Programming Language :: Python :: 3.5',
         'Topic :: Software Development :: Libraries :: Python Modules',
         'Topic :: Software Development :: Quality Assurance',
     ]

--- a/tests/sort_test.py
+++ b/tests/sort_test.py
@@ -1,4 +1,5 @@
-from import_order.sort import sort_by_type, sort_import_names
+from import_order.sort import (canonical_sort_key,
+                               sort_by_type, sort_import_names)
 
 
 def test_sort_by_type():
@@ -45,3 +46,21 @@ def test_sort_all():
     ]
     sorted_ = sort_import_names(import_names, local_package_names)
     assert import_names == sorted_
+
+
+def test_canonical_sort_key():
+    # ensure re is stdlib
+    actual = canonical_sort_key(
+        're.compile', 1, 0, False, local_package_names=['hello']
+    )
+    assert (1, 're', 2, 2, 're.compile') == actual
+    # ensure pygments is site packages
+    actual = canonical_sort_key(
+        'pygments', 1, 0, False, local_package_names=['hello']
+    )
+    assert (2, 'pygments', 2, 2, 'pygments') == actual
+    # ensure hello is local packages
+    actual = canonical_sort_key(
+        'hello', 1, 0, False, local_package_names=['hello']
+    )
+    assert (3, 'hello', 2, 2, 'hello') == actual

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27, py33, py34
+envlist = py27, py33, py34, py35
 
 [testenv]
 deps =


### PR DESCRIPTION
- if site.usersitepackages() return string, call .update will update
  a character as a element.
- so canonical_sort_key treat a standard pacakges(like re) like a site
  packages
