### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,11 +1,11 @@
 import-order
 ==============
 
-.. image:: https://pypip.in/wheel/import_order/badge.svg
+.. image:: https://img.shields.io/pypi/wheel/import_order.svg
     :target: https://pypi.python.org/pypi/import_order/
     :alt: Wheel Status
 
-.. image:: https://pypip.in/py_versions/import_order/badge.svg
+.. image:: https://img.shields.io/pypi/pyversions/import_order.svg
    :target: https://pypi.python.org/pypi/import_order/
    :alt: Supported Python versions
 


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20import-order))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `import-order`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badges to use shields.io instead.